### PR TITLE
Fix Error Unpacking Certain Tar Files.

### DIFF
--- a/unzipit.go
+++ b/unzipit.go
@@ -217,14 +217,23 @@ func Untar(data io.Reader, destPath string) (string, error) {
 			if rootdir == destPath {
 				rootdir = d
 			}
-			os.Mkdir(d, 0740)
+			os.MkdirAll(d, os.FileMode(hdr.Mode))
 			continue
 		}
 
-		file, err := os.Create(filepath.Join(destPath, sanitize(hdr.Name)))
+		path := filepath.Join(destPath, sanitize(hdr.Name))
+		parentDir, _ := filepath.Split(path)
+
+		err = os.MkdirAll(parentDir, 0740)
 		if err != nil {
 			return rootdir, err
 		}
+
+		file, err := os.Create(path)
+		if err != nil {
+			return rootdir, err
+		}
+
 		defer file.Close()
 
 		if _, err := io.Copy(file, tr); err != nil {


### PR DESCRIPTION
I was trying to use `unzipit` today and my test archive was https://repo.wibidata.com/artifactory/kiji/org/kiji/schema/kiji-schema/1.5.0/kiji-schema-1.5.0-release.tar.gz. This was failing to unpack with this error when trying to unpack in `dependencies`:

```
open dependencies/kiji-schema-1.5.0/lib/kiji-schema-platform-api-1.5.0.jar: no such file or directory
```

I'm not exactly sure what the problem is but it turns out that when iterating on the entries, we get to the jar file but we haven't iterated over kiri-schema-1.5.0 and lib yet. So the parent directory doesn't exist and the file creation fails. So I added creation of the parent directory of file entries. 

I haven't been able to create a fixture file that reproduces the problem but this fix does result in successful unpacking of that `tar.gz`.

I thought I'd post this even though I don't have all the answers. 
